### PR TITLE
Ported PID library from 2019 repo, added autotuning + minor adjustments. Created PID test app

### DIFF
--- a/apps/test-pid/main.cpp
+++ b/apps/test-pid/main.cpp
@@ -1,0 +1,116 @@
+#include "mbed.h"
+#include "PID.h"
+
+// Defines
+#define MIN_RPM 0 // change min/max RPMs based on motor used
+#define MAX_RPM 300
+#define COUNTS_PER_REV 1200 // motor property
+#define TIMER_INTERRUPT_FREQ 0.25 // frequency of timer interrupt for input calculation
+#define GOAL_RPM 100.0
+#define K_UPDATE_PERIOD 0.15
+
+// motor direction pin and pwm out pin, modify as needed
+DigitalOut MOTOR_DIR(D8);
+PwmOut MOTOR_PWM_OUT(D9);
+
+// interrupt in to count encoder rises/falls
+InterruptIn encoderCh1(D2);
+InterruptIn encoderCh2(D3);
+
+Serial pc(SERIAL_TX, SERIAL_RX);
+
+PID rpmPIDController(0.010268, 0.0260, 0, K_UPDATE_PERIOD);
+Timer timer;
+
+// Variables
+uint64_t pulseCount = 0;
+uint64_t oldPulseCount = 0;
+float motorRPM = 0.0;
+float motorPWMDuty = 0.0;
+Ticker interruptTimer;
+
+// PID AutoTune config struct for specific DC motor, change depending on actuator
+PID::t_AutoTuneConfig autoTuneConfig = {
+    .nLookBack = 40,
+    .sampleTime = 250,
+    .outputStart = 0.4,
+    .oStep = 0.25,
+    .noiseBand = 0.01,
+    .setpoint = 120
+};
+ 
+// Setup velocity PID controller
+void initializePidController(void) {
+    rpmPIDController.setInputLimits(MIN_RPM, MAX_RPM);
+    rpmPIDController.setOutputLimits(0.0, 1.0);
+    rpmPIDController.setBias(0.0);
+    rpmPIDController.setMode(PID_AUTO_MODE);
+    rpmPIDController.setupAutoTune(&MOTOR_PWM_OUT, &motorRPM, 0);
+}
+
+// every time a pulse is received from the encoder channels, increase the pulse count
+void countPulses() {
+    pulseCount++;
+}
+
+// every timer interrupt, recompute the rpm
+void computeInput() {
+    motorRPM = (pulseCount - oldPulseCount) * (60 / TIMER_INTERRUPT_FREQ) / COUNTS_PER_REV;
+    oldPulseCount = pulseCount;
+}
+ 
+int main() {
+    encoderCh1.rise(&countPulses);  // attach the address of the pulse count function to the rising edge
+    encoderCh1.fall(&countPulses);
+    encoderCh2.rise(&countPulses);
+    encoderCh2.fall(&countPulses);
+
+    pc.baud(9600); // initialize serial
+
+    pc.printf("PID Test - Start \r\n");
+
+    // Initialization
+    float interval = 0.1;
+    initializePidController();
+    rpmPIDController.setSetPoint(GOAL_RPM); // Set RPM set point
+    MOTOR_DIR = 1; // set default direction
+    interruptTimer.attach(&computeInput, TIMER_INTERRUPT_FREQ); // attach function to timer interrupt
+    timer.start();
+
+    // uncomment below line and comment line after for debug output
+    // rpmPIDController.autoTune(&pc, true, &autoTuneConfig);
+    rpmPIDController.autoTune(true, &autoTuneConfig);
+
+    pc.printf("Autotune Params obtained: Kc: %f \t    TauI: %f \t    TauD: %f \r\n", rpmPIDController.getATunePParam(), rpmPIDController.getATuneIParam(), rpmPIDController.getATuneDParam());
+    rpmPIDController.setAutoTuneParams();
+    interruptTimer.detach();
+
+    wait(5);
+
+    Timer eval;
+    eval.start();
+
+    while (1) {
+        motorRPM = (pulseCount - oldPulseCount) * (60 / interval) / COUNTS_PER_REV;
+        oldPulseCount = pulseCount;
+
+        // Update the PID controller
+        rpmPIDController.setInterval(interval);
+        rpmPIDController.setProcessValue(motorRPM);
+        motorPWMDuty = rpmPIDController.compute();
+        MOTOR_PWM_OUT = motorPWMDuty;
+
+        pc.printf("Motor RPM: %f, \t Goal RPM: %f, \t PWM Output: %f\r\n", motorRPM, GOAL_RPM, motorPWMDuty);
+        if (abs(motorRPM - GOAL_RPM) < 1.0)
+        {
+            pc.printf("Time taken to reach goal RPM: %f \r\n", eval.read());
+            MOTOR_DIR = 0;
+            return 0;
+        }
+
+        wait(K_UPDATE_PERIOD);
+
+        interval = timer.read();
+        timer.reset();
+    }
+}

--- a/lib/pid/PID.cpp
+++ b/lib/pid/PID.cpp
@@ -1,0 +1,556 @@
+/**
+ * @author Aaron Berk
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2010 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ * 
+ * A PID controller is a widely used feedback controller commonly found in
+ * industry.
+ *
+ * This library is a port of Brett Beauregard's Arduino PID library:
+ *
+ *  http://www.arduino.cc/playground/Code/PIDLibrary
+ *
+ * The wikipedia article on PID controllers is a good place to start on
+ * understanding how they work:
+ *
+ *  http://en.wikipedia.org/wiki/PID_controller
+ *
+ * For a clear and elegant explanation of how to implement and tune a
+ * controller, the controlguru website by Douglas J. Cooper (who also happened
+ * to be Brett's controls professor) is an excellent reference:
+ *
+ *  http://www.controlguru.com/
+ * 
+ * Additions to original PID library:
+ * 
+ * Autotuning capability, based on this library: 
+ * https://github.com/br3ttb/Arduino-PID-AutoTune-Library
+ * 
+ * Associated blog post:
+ * http://brettbeauregard.com/blog/2012/01/arduino-pid-autotune-library/ 
+ * 
+ * General usage for autotuning:
+ * 1. Create function that calculates required input and attach to a timer
+ * interrupt so it can run in the background (or multithread it)
+ * 2. Add actuator type to enum in PID class if it doesn't exist
+ * 3. Add type cast for actuator type in setOutput() function if it doesn't exist
+ * 4. Using PID object call setupAutoTune() passing it I/O pointers and actuator type
+ * 5. Call autoTune() function, choose whether you want PI or PID control. Also can
+ * pass a autoTuneConfig struct for autotune params (if nothing is passed, default
+ * will be used). 
+ * 6. Highly recommend monitoring autotune loop, try to change outputStart and oStep
+ * such that the output oscillates evenly about the setpoint
+ * 7. Choose whether or not to use autoTune parameters, can set using
+ * setAutoTuneParams() function
+ * 
+ * General note: Don't fully rely on autoTune params, use this as a starting point
+ * for finding the right PID tuning params and test if they work well or not
+ */
+
+/**
+ * Includes
+ */
+
+#include "PID.h"
+
+PID::PID(float Kc, float tauI, float tauD, float interval) {
+
+    usingFeedForward = false;
+    inAuto           = false;
+
+    //Default the limits to the full range of I/O: 3.3V
+    //Make sure to set these to more appropriate limits for
+    //your application.
+    setInputLimits(0.0, 3.3);
+    setOutputLimits(0.0, 3.3);
+
+    tSample_ = interval;
+
+    setTunings(Kc, tauI, tauD);
+
+    setPoint_             = 0.0;
+    processVariable_      = 0.0;
+    prevProcessVariable_  = 0.0;
+    controllerOutput_     = 0.0;
+    prevControllerOutput_ = 0.0;
+
+    accError_       = 0.0;
+    deadZoneError_  = 0.0;
+    bias_           = 0.0;
+    
+    realOutput_ = 0.0;
+
+}
+
+void PID::setInputLimits(float inMin, float inMax) {
+
+    //Make sure we haven't been given impossible values.
+    if (inMin >= inMax) {
+        return;
+    }
+
+    inSpan_ = inMax - inMin;
+
+    //Rescale the working variables to reflect the changes.
+    prevProcessVariable_ *= (inMax - inMin) / inSpan_;
+    accError_            *= (inMax - inMin) / inSpan_;
+
+    //Make sure the working variables are within the new limits.
+    if (prevProcessVariable_ > 1) {
+        prevProcessVariable_ = 1;
+    } else if (prevProcessVariable_ < 0) {
+        prevProcessVariable_ = 0;
+    }
+
+    inMin_  = inMin;
+    inMax_  = inMax;
+    
+
+}
+
+void PID::setOutputLimits(float outMin, float outMax) {
+
+    //Make sure we haven't been given impossible values.
+    if (outMin >= outMax) {
+        return;
+    }
+
+    //Rescale the working variables to reflect the changes.
+    prevControllerOutput_ *= (outMax - outMin) / outSpan_;
+
+    //Make sure the working variables are within the new limits.
+    if (prevControllerOutput_ > 1) {
+        prevControllerOutput_ = 1;
+    } else if (prevControllerOutput_ < 0) {
+        prevControllerOutput_ = 0;
+    }
+
+    outMin_  = outMin;
+    outMax_  = outMax;
+    outSpan_ = outMax - outMin;
+
+}
+
+void PID::setTunings(float Kc, float tauI, float tauD) {
+
+    //Verify that the tunings make sense.
+    if (Kc == 0.0 || tauI < 0.0 || tauD < 0.0) {
+        return;
+    }
+
+    //Store raw values to hand back to user on request.
+    pParam_ = Kc;
+    iParam_ = tauI;
+    dParam_ = tauD;
+
+    float tempTauR;
+
+    if (tauI == 0.0) {
+        tempTauR = 0.0;
+    } else {
+        tempTauR = (1.0 / tauI) * tSample_;
+    }
+
+    //For "bumpless transfer" we need to rescale the accumulated error.
+    if (inAuto) {
+        if (tempTauR == 0.0) {
+            accError_ = 0.0;
+        } else {
+            accError_ *= (Kc_ * tauR_) / (Kc * tempTauR);
+        }
+    }
+
+    Kc_   = Kc;
+    tauR_ = tempTauR;
+    tauD_ = tauD / tSample_;
+
+}
+
+void PID::reset(void) {
+
+    float scaledBias = 0.0;
+
+    if (usingFeedForward) {
+        scaledBias = (bias_ - outMin_) / outSpan_;
+    } else {
+        scaledBias = (realOutput_ - outMin_) / outSpan_;
+    }
+
+    prevControllerOutput_ = scaledBias;
+    prevProcessVariable_  = (processVariable_ - inMin_) / inSpan_;
+
+    //Clear any error in the integral.
+    accError_ = 0;
+
+}
+
+void PID::setMode(int mode) {
+
+    //We were in manual, and we just got set to auto.
+    //Reset the controller internals.
+    if (mode != 0 && !inAuto) {
+        reset();
+    }
+
+    inAuto = (mode != 0);
+
+}
+
+void PID::setInterval(float interval) {
+
+    if (interval > 0) {
+        //Convert the time-based tunings to reflect this change.
+        tauR_     *= (interval / tSample_);
+        accError_ *= (tSample_ / interval);
+        tauD_     *= (interval / tSample_);
+        tSample_   = interval;
+    }
+
+}
+
+void PID::setSetPoint(float sp) {
+
+    setPoint_ = sp;
+
+}
+
+void PID::setProcessValue(float pv) {
+
+    processVariable_ = pv;
+
+}
+
+void PID::setBias(float bias){
+
+    bias_ = bias;
+    usingFeedForward = 1;
+
+}
+
+void PID::setDeadZoneError(float error) {
+
+    deadZoneError_ = error;
+
+}
+
+void PID::setRealOutput(float realOutput) {
+
+    realOutput_ = realOutput;
+
+}
+
+void PID::setupAutoTune(void *outputPointer, float *inputPointer, int actuatorType) {
+
+    // set actuator type
+    actuatorType_ = actuatorType;
+
+    // set I/O pointers
+    output_ = outputPointer;
+    input_ = inputPointer;
+}
+
+// for debug output uncomment below line and comment out line after
+// void PID::autoTune(Serial *pc, bool PI, PID::t_AutoTuneConfig *autoTuneConfig) {
+void PID::autoTune(bool PI, PID::t_AutoTuneConfig *autoTuneConfig) {
+
+    Timer timer;
+    bool isMax, isMin, justchanged;
+	double absMax, absMin, refVal, Ku, Pu;
+	unsigned long peak1, peak2;
+	int peakType, peakCount;
+	double lastInputs[101] = {0};
+    double peaks[10];
+
+    // if no config struct was passed, create one with default values
+    // outputStart = half of range, oStep = 10% of range, noiseBand = 1% of range
+    if (autoTuneConfig == nullptr) {
+        autoTuneConfig = new PID::t_AutoTuneConfig();
+        autoTuneConfig->nLookBack = 40;
+        autoTuneConfig->sampleTime = 250;
+        float outputStart = outMax_ / 2;
+        if (outputStart < outMin_)
+            outputStart = outMin_;
+        autoTuneConfig->outputStart = outputStart;
+        autoTuneConfig->oStep = outSpan_ * 0.15;
+        autoTuneConfig->noiseBand = outSpan_ * 0.01;
+        autoTuneConfig->setpoint = setPoint_;
+    }
+
+    // initialize variables
+    peakType = peakCount = peak1 = peak2 = 0;
+    justchanged = false;
+    refVal = absMax = absMin = autoTuneConfig->setpoint;
+
+    setOutput(autoTuneConfig->outputStart + autoTuneConfig->oStep);
+
+    timer.start();
+
+    while (1) {
+        // for debugging uncomment this line and add serial object as argument (called pc)
+        // pc->printf("Peak count: %d, \t refVal: %f \r\n", peakCount, refVal);
+        // enough peaks to calculate params
+        if (peakCount > 9) {
+            break;
+        }
+
+        unsigned long now = timer.read_ms();
+
+        refVal = *input_;
+
+        if (refVal>absMax && refVal < inMax_)
+            absMax=refVal;
+		if (refVal<absMin && refVal < inMin_)
+            absMin=refVal;
+
+        // oscillate output
+        if(refVal > autoTuneConfig->setpoint + autoTuneConfig->noiseBand) {
+            setOutput(autoTuneConfig->outputStart - autoTuneConfig->oStep);
+        }
+	    else if (refVal < autoTuneConfig->setpoint - autoTuneConfig->noiseBand) {
+            setOutput(autoTuneConfig->outputStart + autoTuneConfig->oStep);
+        }
+
+        isMax = isMin = true;
+
+        //id peaks
+        for (int i = autoTuneConfig->nLookBack-1; i>=0; i--)
+        {
+            double val = lastInputs[i];
+            if(isMax)
+                isMax = refVal>val;
+            if(isMin) 
+                isMin = refVal<val;
+            lastInputs[i+1] = lastInputs[i];
+        }
+        lastInputs[0] = refVal;  
+
+        if(isMax)
+        {
+            if(peakType==0)
+                peakType=1;
+            if(peakType==-1)
+            {
+                peakType = 1;
+                justchanged = true;
+                peak2 = peak1;
+            }
+            peak1 = now;
+            peaks[peakCount] = refVal;
+        
+        }
+        else if(isMin)
+        {
+            if(peakType==0)
+                peakType=-1;
+            if(peakType==1)
+            {
+                peakType=-1;
+                peakCount++;
+                justchanged=true;
+            }
+            
+            if (peakCount<10)
+                peaks[peakCount] = refVal;
+        }
+
+        // Transition, check if we can autotune based on the last peaks
+        if(justchanged && peakCount>2)
+        { 
+            double avgSeparation = (abs(peaks[peakCount-1]-peaks[peakCount-2])+abs(peaks[peakCount-2]-peaks[peakCount-3]))/2;
+            if( avgSeparation < 0.05*(absMax-absMin) )
+                break;
+        }
+        justchanged = false;
+
+        // wait for sample time interval
+        while( (timer.read_ms() - now) < autoTuneConfig->sampleTime);
+    }
+
+    // calculate autotune parameters
+    Ku = 4 * (2 * autoTuneConfig->oStep) / ((absMax-absMin) * 3.14159);
+    Pu = (double)(peak1-peak2) / 1000;
+
+    // if we only PI control is desired, alternate calculations and TauD set to 0
+    if (PI) {
+        autoTuneKc_ = 0.45 * Ku;
+        autoTuneTauR_ = 0.54*Ku / Pu;
+        autoTuneTauD_ = 0;
+    }
+    else {
+        autoTuneKc_ = 0.6 * Ku;
+        autoTuneTauR_ = 1.2*Ku / Pu;
+        autoTuneTauD_ = 0.075 * Ku * Pu;
+    }
+}
+
+void PID::setOutput(float output) {
+    
+    // bound output to limits
+    if (output > outMax_)
+        output = outMax_;
+    else if (output < outMin_)
+        output = outMin_;
+        
+    // cast void pointer based on required output type
+    // add desired output types here and convert from float as necessary
+    switch (actuatorType_)
+    {
+        case PWM_MOTOR: {
+            *static_cast<PwmOut*>(output_) = output;
+            break;
+        }
+        default:
+            *(float *)output_ = output;
+    }
+}
+
+void PID::setAutoTuneParams() {
+    setTunings(autoTuneKc_, autoTuneTauR_, autoTuneTauD_);
+}
+
+float PID::compute() {
+
+    //Pull in the input and setpoint, and scale them into percent span.
+    float scaledPV = (processVariable_ - inMin_) / inSpan_;
+
+    if (scaledPV > 1.0) {
+        scaledPV = 1.0;
+    } else if (scaledPV < 0.0) {
+        scaledPV = 0.0;
+    }
+
+    float scaledSP = (setPoint_ - inMin_) / inSpan_;
+    if (scaledSP > 1.0) {
+        scaledSP = 1;
+    } else if (scaledSP < 0.0) {
+        scaledSP = 0;
+    }
+
+    float error = scaledSP - scaledPV;
+
+    if (fabs(error) < deadZoneError_) {
+        error = 0;
+    }
+
+    //Check and see if the output is pegged at a limit and only
+    //integrate if it is not. This is to prevent reset-windup.
+    if (!(prevControllerOutput_ >= 1 && error > 0) && !(prevControllerOutput_ <= 0 && error < 0)) {
+        accError_ += error;
+    }
+
+    //Compute the current slope of the input signal.
+    float dMeas = (scaledPV - prevProcessVariable_) / tSample_;
+
+    float scaledBias = 0.0;
+
+    if (usingFeedForward) {
+        scaledBias = (bias_ - outMin_) / outSpan_;
+    }
+
+    //Perform the PID calculation.
+    controllerOutput_ = scaledBias + Kc_ * (error + (tauR_ * accError_) - (tauD_ * dMeas));
+
+    //Make sure the computed output is within output constraints.
+    if (controllerOutput_ < 0.0) {
+        controllerOutput_ = 0.0;
+    } else if (controllerOutput_ > 1.0) {
+        controllerOutput_ = 1.0;
+    }
+
+    //Remember this output for the windup check next time.
+    prevControllerOutput_ = controllerOutput_;
+    //Remember the input for the derivative calculation next time.
+    prevProcessVariable_  = scaledPV;
+
+    //Scale the output from percent span back out to a real world number.
+    return ((controllerOutput_ * outSpan_) + outMin_);
+
+}
+
+float PID::getInMin() {
+
+    return inMin_;
+
+}
+
+float PID::getInMax() {
+
+    return inMax_;
+
+}
+
+float PID::getOutMin() {
+
+    return outMin_;
+
+}
+
+float PID::getOutMax() {
+
+    return outMax_;
+
+}
+
+float PID::getInterval() {
+
+    return tSample_;
+
+}
+
+float PID::getPParam() {
+
+    return pParam_;
+
+}
+
+float PID::getIParam() {
+
+    return iParam_;
+
+}
+
+float PID::getDParam() {
+
+    return dParam_;
+
+}
+
+float PID::getATunePParam() {
+
+    return autoTuneKc_;
+
+}
+
+float PID::getATuneIParam() {
+
+    return autoTuneTauR_;
+
+}
+
+float PID::getATuneDParam() {
+
+    return autoTuneTauD_;
+
+}

--- a/lib/pid/PID.h
+++ b/lib/pid/PID.h
@@ -289,25 +289,4 @@ private:
     volatile float realOutput_;
 };
 
-// struct holding all the autoTune variables to store large number of variables between function calls
-struct autoTuneParams {
-    bool isMax, isMin, justchanged, justevaled, done;
-    double lastInputs[101] = {0};
-    double peaks[10];
-    int sampleTime, nLookBack, peakType, peakCount, controlType;
-    unsigned long peak1, peak2, currentTime;
-    double setpoint, noiseBand, absMax, absMin, oStep, refVal, output, outputStart;
-    Timer t;
-
-    autoTuneParams(float setpoint_, double oStep_=130, double noiseBand_=0.5, int sampleTime_=250, double outputStart_=160.0) {
-        setpoint = refVal = absMax = absMin = setpoint_;
-        peakType = peakCount = 0;
-        justchanged = done = false;
-        oStep = oStep_;
-        noiseBand = noiseBand_;
-        sampleTime = sampleTime_;
-        outputStart = outputStart_;
-    }
-};
-
 #endif /* PID_H */

--- a/lib/pid/PID.h
+++ b/lib/pid/PID.h
@@ -1,0 +1,313 @@
+/**
+ * @author Aaron Berk
+ *
+ * @section LICENSE
+ *
+ * Copyright (c) 2010 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @section DESCRIPTION
+ * 
+ * A PID controller is a widely used feedback controller commonly found in
+ * industry.
+ *
+ * This library is a port of Brett Beauregard's Arduino PID library:
+ *
+ *  http://www.arduino.cc/playground/Code/PIDLibrary
+ *
+ * The wikipedia article on PID controllers is a good place to start on
+ * understanding how they work:
+ *
+ *  http://en.wikipedia.org/wiki/PID_controller
+ *
+ * For a clear and elegant explanation of how to implement and tune a
+ * controller, the controlguru website by Douglas J. Cooper (who also happened
+ * to be Brett's controls professor) is an excellent reference:
+ *
+ *  http://www.controlguru.com/
+ */
+
+#ifndef PID_H
+#define PID_H
+
+/**
+ * Includes
+ */
+#include "mbed.h"
+
+/**
+ * Defines
+ */
+#define PID_MANUAL_MODE 0
+#define PID_AUTO_MODE   1
+
+/**
+ * Proportional-integral-derivative controller.
+ */
+class PID {
+
+public:
+
+    typedef struct {
+        float P, I, D, bias;
+        float interval;
+
+    } t_pidConfig;
+
+    // add other actuators here
+    enum ActuatorType
+    {
+        PWM_MOTOR
+    };
+
+    // configurable parameters for autotuning process
+    typedef struct {
+        int nLookBack;
+        unsigned long sampleTime;
+        double outputStart, oStep, noiseBand, setpoint;
+    } t_AutoTuneConfig;
+
+    /**
+     * Constructor.
+     *
+     * Sets default limits [0-3.3V], calculates tuning parameters, and sets
+     * manual mode with no bias.
+     *
+     * @param Kc - Tuning parameter
+     * @param tauI - Tuning parameter
+     * @param tauD - Tuning parameter
+     * @param interval PID calculation performed every interval seconds.
+     */
+    PID(float Kc, float tauI, float tauD, float interval);
+
+    /**
+     * Scale from inputs to 0-100%.
+     *
+     * @param InMin The real world value corresponding to 0%.
+     * @param InMax The real world value corresponding to 100%.
+     */
+    void setInputLimits(float inMin , float inMax);
+
+    /**
+     * Scale from outputs to 0-100%.
+     *
+     * @param outMin The real world value corresponding to 0%.
+     * @param outMax The real world value corresponding to 100%.
+     */
+    void setOutputLimits(float outMin, float outMax);
+
+    /**
+     * Calculate PID constants.
+     *
+     * Allows parameters to be changed on the fly without ruining calculations.
+     *
+     * @param Kc - Tuning parameter
+     * @param tauI - Tuning parameter
+     * @param tauD - Tuning parameter
+     */
+    void setTunings(float Kc, float tauI, float tauD);
+
+    /**
+     * Reinitializes controller internals. Automatically
+     * called on a manual to auto transition.
+     */
+    void reset(void);
+    
+    /**
+     * Set PID to manual or auto mode.
+     *
+     * @param mode        0 -> Manual
+     *             Non-zero -> Auto
+     */
+    void setMode(int mode);
+    
+    /**
+     * Set how fast the PID loop is run.
+     *
+     * @param interval PID calculation peformed every interval seconds.
+     */
+    void setInterval(float interval);
+    
+    /**
+     * Set the set point.
+     *
+     * @param sp The set point as a real world value.
+     */
+    void setSetPoint(float sp);
+    
+    /**
+     * Set the process value.
+     *
+     * @param pv The process value as a real world value.
+     */
+    void setProcessValue(float pv);
+    
+    /**
+     * Set the bias.
+     *
+     * @param bias The bias for the controller output.
+     */
+    void setBias(float bias);
+
+    /**
+     * Set the dead zone error to allow error to round down if within +/- this value
+     * @param error Round error down to 0.0 if error is within +/- this value
+     */
+    void setDeadZoneError(float error);
+
+    /**
+     * Set real output value
+     * @param realOutput real life output
+     */
+    void setRealOutput(float realOutput);
+
+
+    /**
+     * Setup needed before autotuning
+     * @param outputPointer generic pointer to actual output (ex. PWM pin)
+     * @param inputPointer pointer to calculated input value, usually done in background on main
+     * @param actuatorType type of actuator needed to cast generic void pointer 
+     */
+    void setupAutoTune(void *outputPointer, float *inputPointer, int actuatorType);
+    
+    /**
+     * Run the autotuning algorithm and set autoTune class member variables
+     * @param PI choose between PI and PID control, calculation is different
+     * @param autoTuneConfig pointer to config struct for autotune, optional
+     */
+    // uncomment below line and comment line after for debug output
+    // void autoTune(Serial *pc, bool PI, t_AutoTuneConfig *autoTuneConfig = nullptr);
+    void autoTune(bool PI, t_AutoTuneConfig *autoTuneConfig = nullptr);
+    
+    /**
+     * Set the output from within the PID class, needed for autotuning
+     * @param output output as a float, casting done in function based on actuator type
+     */
+    void setOutput(float output);
+
+    /**
+     * Set the tuning values to the calculated autotuning parameters
+     */
+    void setAutoTuneParams();
+
+    /**
+     * PID calculation.
+     *
+     * @return The controller output as a float between outMin and outMax.
+     */
+    float compute(void);
+
+    //Getters.
+    float getInMin();
+    float getInMax();
+    float getOutMin();
+    float getOutMax();
+    float getInterval();
+    float getPParam();
+    float getIParam();
+    float getDParam();
+    float getATunePParam();
+    float getATuneIParam();
+    float getATuneDParam();
+
+private:
+
+    bool usingFeedForward;
+    bool inAuto;
+
+    //Actual tuning parameters used in PID calculation.
+    float Kc_;
+    float tauR_;
+    float tauD_;
+
+    //Tuning parameters calculated from autotuning function
+    float autoTuneKc_;
+    float autoTuneTauR_;
+    float autoTuneTauD_;
+
+    //Input/Output pointers for AutoTuning
+    void *output_;
+    float *input_;
+
+    //Store type of actuator PID is being used on
+    int actuatorType_;
+
+    //Struct with all the autotune parameters
+    t_AutoTuneConfig AutoTuneConfig;
+    
+    //Raw tuning parameters.
+    float pParam_;
+    float iParam_;
+    float dParam_;
+    
+    //The point we want to reach.
+    float setPoint_;         
+    //The thing we measure.
+    float processVariable_;  
+    float prevProcessVariable_;
+    //The output that affects the process variable.
+    float controllerOutput_; 
+    float prevControllerOutput_;
+
+    //We work in % for calculations so these will scale from
+    //real world values to 0-100% and back again.
+    float inMin_;
+    float inMax_;
+    float inSpan_;
+    float outMin_;
+    float outMax_;
+    float outSpan_;
+
+    //The accumulated error, i.e. integral.
+    float accError_;
+    //The allowed error range for error to be rounded to 0.0
+    float deadZoneError_;
+    //The controller output bias.
+    float bias_;
+
+    //The interval between samples.
+    float tSample_;          
+
+    //Controller output as a real world value.
+    volatile float realOutput_;
+};
+
+// struct holding all the autoTune variables to store large number of variables between function calls
+struct autoTuneParams {
+    bool isMax, isMin, justchanged, justevaled, done;
+    double lastInputs[101] = {0};
+    double peaks[10];
+    int sampleTime, nLookBack, peakType, peakCount, controlType;
+    unsigned long peak1, peak2, currentTime;
+    double setpoint, noiseBand, absMax, absMin, oStep, refVal, output, outputStart;
+    Timer t;
+
+    autoTuneParams(float setpoint_, double oStep_=130, double noiseBand_=0.5, int sampleTime_=250, double outputStart_=160.0) {
+        setpoint = refVal = absMax = absMin = setpoint_;
+        peakType = peakCount = 0;
+        justchanged = done = false;
+        oStep = oStep_;
+        noiseBand = noiseBand_;
+        sampleTime = sampleTime_;
+        outputStart = outputStart_;
+    }
+};
+
+#endif /* PID_H */


### PR DESCRIPTION
Ported the PID library from the 2019 repo

Inside setInputLimits() changed inSpan_ to be set prior to division to avoid undefined division.
Added setter for realOutput_ member variable which could not be accessed before

Created autotuning capability based on https://github.com/br3ttb/Arduino-PID-AutoTune-Library and modified significantly to make it usable as a class function

Created test-pid app for testing and future use