### PR TITLE
fix \n

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository contains:
 	      sudo apt autoremove gcc-arm-none-eabi
           wget https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2
           sudo tar -xvf gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 -C /opt/
-          echo "\nPATH=\$PATH:/opt/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc
+          echo "PATH=\$PATH:/opt/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc
           export PATH=$PATH:/opt/gcc-arm-none-eabi-9-2019-q4-major/bin 
 
 	


### PR DESCRIPTION
in the readme, this cmd is giving some ppl trouble. echo "\nPATH=\$PATH:/opt/gcc-arm-none-eabi-9-2019-q4-major/bin" >> ~/.bashrc

the \n doesnt do what it was thought to do and gives ppl a no such file or directory error everytime they source their bash terminal. the \n shouldnt be there.