### PR TITLE
Update CXX_FLAG 

### DIFF
--- a/makefile
+++ b/makefile
@@ -223,7 +223,7 @@ C_FLAGS += -std=gnu11
 C_FLAGS += ${DEFINITIONS}
 C_FLAGS += ${COMMON_FLAGS}
 
-CXX_FLAGS += -std=gnu++14
+CXX_FLAGS += -std=gnu++2a
 CXX_FLAGS += -fno-rtti
 CXX_FLAGS += -Wvla
 CXX_FLAGS += ${DEFINITIONS}


### PR DESCRIPTION
Update CXX_FLAG  std=gnu++14 to std=gnu++2a so that we don't have warnings for the way we declare struct currently.
See discussion here:
https://github.com/uwrobotics/MarsRover2020-firmware/pull/90