### PR TITLE
HW Bridge Submodule to Use Absolute Path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 
 [submodule "uwrt-mars-rover-hw-bridge"]
     path = uwrt-mars-rover-hw-bridge
-    url = ../uwrt_mars_rover_hw_bridge.git
+    url = https://github.com/uwrobotics/uwrt_mars_rover_hw_bridge.git


### PR DESCRIPTION
There was an issue with the hw bridge submodule, where it used the relative path. This was a problem if users forked the repo and tried to clone submodules